### PR TITLE
fix for issue #7: slow block sync after failing epoch switch

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -6,7 +6,10 @@
                 "minimumBlockTime": 30,
                 "maximumBlockTime": 300,
                 "transactionQueueSizeTrigger": 1,
-                "blockRewardContractAddress": "0x2000000000000000000000000000000000000001"
+                "blockRewardContractAddress": "0x2000000000000000000000000000000000000001",
+                "blockRewardSkips" : [
+                    { "fromBlock": 5841 }
+                ]
             }
         }
     },


### PR DESCRIPTION
https://github.com/DMDcoin/Diamond/issues/7
defined a blockRewardSkip section for the problematic epoch switch at staking epoch 22 with block starting  5841.
