### PR TITLE
RPC Node default port for devP2P is now 17771.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+validator_node.toml
+data
+diamond-node
+diamond-node-git
+diamond-node.log
+dmd

--- a/rpcnode.toml
+++ b/rpcnode.toml
@@ -18,7 +18,7 @@ interface = "all"
 max_peers = 30
 min_peers = 5
 nat = "none"
-port = 27272
+port = 17771
 reserved_peers = "reserved-peers"
 
 [parity]


### PR DESCRIPTION
+ added .gitignore file.
+ RPC Node default port for devP2P is now 17771