### PR TITLE
Epoch22 Incident: reactivation of normal behaviour with Block 67800

### DIFF
--- a/spec.json
+++ b/spec.json
@@ -3,12 +3,15 @@
     "engine": {
         "hbbft": {
             "params": {
-                "minimumBlockTime": 30,
+                "minimumBlockTime": 3,
                 "maximumBlockTime": 300,
                 "transactionQueueSizeTrigger": 1,
                 "blockRewardContractAddress": "0x2000000000000000000000000000000000000001",
-                "blockRewardSkips" : [
-                    { "fromBlock": 5841 }
+                "blockRewardSkips": [
+                    {
+                        "fromBlock": 5841,
+                        "toBlock": 67800
+                    }
                 ]
             }
         }


### PR DESCRIPTION
Reactivation of normal epoch end blocks at block  67800. reverting minimumBlockTime to 3 seconds again.  https://github.com/DMDcoin/Diamond/issues/6